### PR TITLE
Hotfix/ghi 11 fix dep pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] [Patch] - 2025-01-03
+### Fixed:
+- Properly pin `patomic` version to `v0.2.2` even if `patomic` has a stable
+  release (which it now does)
+
 ## [1.0.2] [Patch] - 2021-12-10
 ### Changed
 - freeze default `patomic` version to `v0.2.2` until `patomic` has a stable 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = atomics
-version = 1.0.2
+version = 1.0.3
 description = Atomic lock-free primitives
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,9 @@ class BuildPatomicCommand(Command):
 
     def initialize_options(self) -> None:
         self.git_url = "https://github.com/doodspav/patomic"
-        self.git_tag = None
+        # pin to patomic v0.2.2 until we migrate to stable release
+        # self.git_tag = None
+        self.git_tag = "v0.2.2"
         self.dest_dir = here / "src" / "atomics" / "_clib"
         self.build_type = "RelWithDebInfo"
         self.force_replace = False
@@ -181,11 +183,8 @@ class BuildPatomicCommand(Command):
         if self.git_tag:
             self.logger.info(f"Checkout out user provided tag: {self.git_tag}")
             repo.git.checkout(self.git_tag)
-        # switch to backup if provided tag or default branch isn't populated
-        backup = "v0.2.2"  # frozen until patomic has a stable release
-        self.logger.info(f"Switching to {backup} tag")
-        if not (clone_into / "src").is_dir():
-            repo.git.checkout(backup)
+            if not (clone_into / "src").is_dir():
+                self.logger.warning(f"No src directory found in checked out tag: {self.git_tag}")
 
     def config_patomic(self, repo_dir: pathlib.Path) -> None:
         """Configures CMake for in repo_dir"""


### PR DESCRIPTION
## Issue:

The dependency `patomic` was pinned to tag `v0.2.2` only if no stable version of the library existed. A stable version now exists, but is binary incompatible with `v0.2.2`, causing runtime failures.

## Fix:

Unconditionally pin `patomic` to tag `v0.2.2`.